### PR TITLE
Enable the "Always edit" toggle option

### DIFF
--- a/Talented/core.lua
+++ b/Talented/core.lua
@@ -281,7 +281,7 @@ function Talented:SetTemplate(template)
 end
 
 function Talented:GetDefaultMode()
-	return "edit"--self.db.profile.always_edit and "edit" or "view"
+	return self.db.profile.always_edit and "edit" or "view"
 end
 
 function Talented:OnEnable()
@@ -344,6 +344,10 @@ function Talented:ToggleTalentFrame()
 	local frame = self.base
 	if not frame or not frame:IsVisible() then
 		self:Update()
+		if self.template then
+			-- reset editing mode to the default every time we open the panel after the initial open
+			self:SetMode(self:GetDefaultMode())
+		end
 		ShowUIPanel(self.base)
 	else
 		HideUIPanel(frame)

--- a/Talented/options.lua
+++ b/Talented/options.lua
@@ -7,7 +7,7 @@ Talented.defaults = {
 	profile = {
 
 -- Always Edit the template, never lock
-		-- always_edit = nil,
+		always_edit = nil,
 
 -- Manually confirm each talent before learning
 		confirmlearn = true,
@@ -86,13 +86,13 @@ Talented.options = {
 					type = "header",
 					order = 1,
 				},
-				-- always_edit = {
-				-- 	name = L["Always edit"],
-				-- 	desc = L["Always allow templates and the current build to be modified, instead of having to Unlock them first."],
-				-- 	type = "toggle",
-				-- 	arg = "UpdateView",
-				-- 	order = 100,
-				-- },
+				always_edit = {
+					name = L["Always edit"],
+					desc = L["Always allow templates and the current build to be modified, instead of having to Unlock them first."],
+					type = "toggle",
+					arg = "SetMode",
+					order = 100,
+				},
 				confirmlearn = {
 					name = L["Confirm Learning"],
 					desc = L["Ask for user confirmation before learning any talent."],


### PR DESCRIPTION
The "Edit talents" button will now follow the option when opening the talent tree window.

I don't know why this was commented out in the first place, but with this change the option seems to behave as the description describes.