### PR TITLE
Update spell.lua

### DIFF
--- a/Talented/spell.lua
+++ b/Talented/spell.lua
@@ -248,5 +248,6 @@ function Talented:GetTalentLink(template, tab, index, rank)
 		rank = 1
 	end
 	return
-		("|cff71d5ff|Hspell:%d|h[%s]|h|r"):format(data[tab][index].ranks[rank], self:GetTalentName(template.class, tab, index))
+	local link = GetTalentLink(tab,index)
+	return link
 end


### PR DESCRIPTION
fixed error while linking talents:
Talented\spell.lua:251: attempt to index field '?' (a nil value)
[string "@Talented\spell.lua"]:251: in function `GetTalentLink'
[string "@Talented\view.lua"]:342: in function `OnTalentClick'
[string "@Talented\ui\buttons.lua"]:24: in function <Talented\ui\buttons.lua:22>

tested on wow bcc client - but only works with the current character talents!